### PR TITLE
Handle large queues with a disk backed queue

### DIFF
--- a/lib/starling/disk_backed_queue.rb
+++ b/lib/starling/disk_backed_queue.rb
@@ -1,0 +1,124 @@
+module StarlingServer
+  class DiskBackedQueue
+    MAX_LOGFILE_SIZE = 10_000
+    LOGGED_MESSAGE_HEADER_LENGTH = [1].pack("I").size
+
+    attr_reader :total_items
+
+    def initialize(persistence_path, queue_name)
+      @persistence_path, @queue_name = persistence_path, queue_name
+      @active_log_file_name = latest_log_file
+      data = load_log(@active_log_file_name)
+      @active_log_file_size = data.size
+      @total_items = 0
+      if @active_log_file_name.nil?
+        @active_log_file_name = new_logfile_name
+        FileUtils.mkdir_p(File.dirname(@active_log_file_name))
+      end
+      @active_log_file = File.open(@active_log_file_name, "ab")
+    end
+
+    def any?
+      @active_log_file_size > 0 or available_log_files.size > 1
+    end
+
+    def empty?
+      !any?
+    end
+
+    def length
+      (available_log_files.size - 1) * MAX_LOGFILE_SIZE + @active_log_file_size
+    end
+
+    def logsize
+      available_log_files.inject(0){|sum, f| sum + File.size(f) }
+    end
+
+    def push(data)
+      Thread.exclusive do
+        rotate! if @active_log_file_size >= MAX_LOGFILE_SIZE
+        @active_log_file << [data.size].pack("I") + data
+        @active_log_file.flush
+        @active_log_file_size += 1
+        @total_items += 1
+      end
+    end
+
+    def consume_log_into(queue)
+      Thread.exclusive do
+        return unless file = first_log_file
+        return if @active_log_file_name == file and @active_log_file_size.zero?
+
+        rotate! if @active_log_file_name == file
+
+        load_log(file){|i| queue.push(i) }
+        File.unlink(file)
+      end
+    end
+
+    def close
+      @active_log_file.close if @active_log_file
+      @active_log_file = nil
+    end
+
+    def initial_bytes
+      logsize - length * LOGGED_MESSAGE_HEADER_LENGTH
+    end
+
+    def purge
+      close
+      FileUtils.rm_r( File.join(@persistence_path, "disk_backed_queue", @queue_name) )
+      @active_log_file_size = 0
+      rotate!
+    end
+
+  protected
+
+    def available_log_files
+      Dir[File.join(@persistence_path, "disk_backed_queue", @queue_name, "*")].sort
+    end
+
+    def rotate!
+      close
+      @active_log_file_name = new_logfile_name
+      @active_log_file_size = 0
+      FileUtils.mkdir_p(File.dirname(@active_log_file_name))
+      @active_log_file = File.open(@active_log_file_name, "ab")
+    end
+
+    def new_logfile_name(suffix = 0)
+      name = File.join(@persistence_path, "disk_backed_queue", @queue_name, "%s-%03i" % [Time.now.to_i, suffix])
+      if File.exists?( name )
+        new_logfile_name(suffix + 1)
+      else
+        name
+      end
+    end
+
+    def latest_log_file
+      available_log_files.last
+    end
+
+    def first_log_file
+      available_log_files.first
+    end
+
+    def load_log(file, &block)
+      return [] unless file
+      data = []
+      File.open(file){|f|
+        while raw_size = f.read(LOGGED_MESSAGE_HEADER_LENGTH)
+          next unless raw_size
+          size = raw_size.unpack("I").first
+          item = f.read(size)
+          if block_given?
+            yield item
+          else
+            data << item
+          end
+        end
+      }
+      data
+    end
+  end
+end

--- a/lib/starling/disk_backed_queue_with_persistent_queue_buffer.rb
+++ b/lib/starling/disk_backed_queue_with_persistent_queue_buffer.rb
@@ -1,0 +1,77 @@
+require 'starling/disk_backed_queue'
+require 'starling/persistent_queue'
+
+module StarlingServer
+  class DiskBackedQueueWithPersistentQueueBuffer
+    MAX_PRIMARY_SIZE = 10_000
+    def initial_bytes
+      @primary.initial_bytes + @backing.initial_bytes
+    end
+
+    def total_items
+      @primary.total_items + @backing.total_items
+    end
+
+    def current_age
+      @primary.current_age
+    end
+
+    def logsize
+      @primary.logsize
+    end
+
+    def backing_logsize
+      @backing.logsize
+    end
+
+    def length
+      @primary.length + @backing.length
+    end
+
+    def primary_length
+      @primary.length
+    end
+
+    def backing_length
+      @backing.length
+    end
+
+    def initialize(primary, backing)
+      @primary = primary
+      @backing = backing
+    end
+
+    def push(data)
+      if should_go_to_backing?
+        @backing.push(data)
+      else
+        @primary.push(data)
+      end
+    end
+
+    def purge
+      @primary.purge
+      @backing.purge
+    end
+
+    def empty?
+      @primary.empty? and @backing.empty?
+    end
+
+    def pop
+      @backing.consume_log_into(@primary) if @primary.empty?
+      @primary.pop
+    end
+
+    def close
+      @primary.close
+      @backing.close
+    end
+
+  protected
+    def should_go_to_backing?
+      return true if @primary.length >= MAX_PRIMARY_SIZE
+      @backing.any?
+    end
+  end
+end

--- a/lib/starling/handler.rb
+++ b/lib/starling/handler.rb
@@ -52,7 +52,10 @@ STAT limit_maxbytes %d\r
 STAT queue_%s_total_items %d\r
 STAT queue_%s_logsize %d\r
 STAT queue_%s_expired_items %d\r
-STAT queue_%s_age %d\r\n".freeze
+STAT queue_%s_age %d\r
+STAT queue_%s_backinglogsize %d\r
+STAT queue_%s_primaryitems %d\r
+STAT queue_%s_backingitems %d\r\n".freeze
 
     SHUTDOWN_COMMAND = /\Ashutdown\r\n/m
 
@@ -226,7 +229,10 @@ STAT queue_%s_age %d\r\n".freeze
                       k, v.total_items,
                       k, v.logsize,
                       k, @expiry_stats[k],
-                      k, v.current_age)
+                      k, v.current_age,
+                      k, v.backing_logsize,
+                      k, v.primary_length,
+                      k, v.backing_length)
       end
     end
 

--- a/lib/starling/handler.rb
+++ b/lib/starling/handler.rb
@@ -24,7 +24,7 @@ module StarlingServer
     SET_CLIENT_DATA_ERROR = "CLIENT_ERROR bad data chunk\r\nERROR\r\n".freeze
     
     # DELETE Responses
-    DELETE_COMMAND = /\Adelete (.{1,250}) ([0-9]+)\r\n/m
+    DELETE_COMMAND = /\Adelete (.{1,250})(?: ([0-9]+))?\r\n/m
     DELETE_RESPONSE = "END\r\n".freeze
 
     # STAT Response

--- a/lib/starling/queue_collection.rb
+++ b/lib/starling/queue_collection.rb
@@ -1,5 +1,5 @@
 require 'thread'
-require 'starling/persistent_queue'
+require 'starling/disk_backed_queue_with_persistent_queue_buffer'
 
 module StarlingServer
   class InaccessibleQueuePath < Exception #:nodoc:
@@ -49,7 +49,7 @@ module StarlingServer
 
     def take(key)
       queue = queues(key)
-      if queue.nil? || queue.length == 0
+      if queue.nil? || queue.empty?
         @stats[:get_misses] += 1
         return nil
       else
@@ -94,7 +94,7 @@ module StarlingServer
           # been loaded. There's a race condition otherwise, and we could
           # end up loading the queue multiple times.
           if @queues[key].nil?
-            @queues[key] = PersistentQueue.new(@path, key)
+            @queues[key] = new_queue(@path, key)
             @stats[:current_bytes] += @queues[key].initial_bytes
           end
         rescue Object => exc
@@ -106,6 +106,13 @@ module StarlingServer
       end
 
       return @queues[key]
+    end
+
+    def new_queue(path, name)
+      DiskBackedQueueWithPersistentQueueBuffer.new(
+        PersistentQueue.new(path, name),
+        DiskBackedQueue.new(path, name)
+      )
     end
 
     ##

--- a/lib/starling/queue_collection.rb
+++ b/lib/starling/queue_collection.rb
@@ -27,6 +27,7 @@ module StarlingServer
       @queue_init_mutexes = {}
 
       @stats = Hash.new(0)
+      initialize_existing_queues!
     end
 
     ##
@@ -139,6 +140,13 @@ module StarlingServer
     end
 
     private
+
+    def initialize_existing_queues!
+      Dir.glob(File.join(@path, "*")).each {|file|
+        next if File.directory?( file )
+        queues(File.basename(file))
+      }
+    end
 
     def current_size #:nodoc:
       @queues.inject(0) { |m, (k,v)| m + v.length }

--- a/spec/disk_backed_queue_spec.rb
+++ b/spec/disk_backed_queue_spec.rb
@@ -1,0 +1,95 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+MAX_LOGFILE_SIZE = StarlingServer::DiskBackedQueue::MAX_LOGFILE_SIZE
+TOO_MUCH_DATA = (0..MAX_LOGFILE_SIZE).map{|v| v.to_s}
+describe "StarlingServer::DiskBackedQueue" do
+  before do
+    @tmp_path = File.join(File.dirname(__FILE__), "tmp")
+    @queue = StarlingServer::DiskBackedQueue.new(@tmp_path, "disk_backed_queue")
+  end
+
+  it "should push messages" do
+    @queue.length.should == 0
+    @queue.push("message")
+    @queue.length.should == 1
+  end
+
+  it "should consume itself in order" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+    output_array = []
+    @queue.consume_log_into(output_array)
+    output_array.should == TOO_MUCH_DATA[0...MAX_LOGFILE_SIZE]
+    @queue.consume_log_into(output_array)
+    output_array.should == TOO_MUCH_DATA
+  end
+
+  it "should know if it's empty? or any?" do
+    @queue.empty?.should == true
+    @queue.any?.should == false
+
+    @queue.push "a"
+
+    @queue.empty?.should == false
+    @queue.any?.should == true
+
+    @queue.consume_log_into([])
+
+    @queue.empty?.should == true
+    @queue.any?.should == false
+  end
+
+  it "should purge" do
+    @queue.push "a"
+    @queue.should_not be_empty
+    @queue.purge
+    @queue.should be_empty
+    @queue.consume_log_into(array = [])
+    array.should be_empty
+  end
+
+  it "should know it's total items" do
+    @queue.push "a"
+    @queue.purge
+    @queue.should be_empty
+    @queue.push "a"
+    @queue.total_items.should == 2
+  end
+
+  it "should report logsize as the size on disk of the queue" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+    header_size = StarlingServer::DiskBackedQueue::LOGGED_MESSAGE_HEADER_LENGTH
+    @queue.logsize.should == header_size * TOO_MUCH_DATA.size + TOO_MUCH_DATA.to_s.size
+  end
+
+  it "should report logsize as the size on disk of the queue even after a reload" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+    @queue = StarlingServer::DiskBackedQueue.new(@tmp_path, "disk_backed_queue")
+    header_size = StarlingServer::DiskBackedQueue::LOGGED_MESSAGE_HEADER_LENGTH
+    @queue.logsize.should == header_size * TOO_MUCH_DATA.size + TOO_MUCH_DATA.to_s.size
+  end
+
+  it "should know how long it is" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+    @queue.length.should == TOO_MUCH_DATA.size
+  end
+
+  it "should know how long it is even after a restart" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+    @queue = StarlingServer::DiskBackedQueue.new(@tmp_path, "disk_backed_queue")
+    @queue.length.should == TOO_MUCH_DATA.size
+  end
+
+  it "should restore itself" do
+    TOO_MUCH_DATA.each{|v| @queue.push v }
+
+    @queue = StarlingServer::DiskBackedQueue.new(@tmp_path, "disk_backed_queue")
+
+    @queue.consume_log_into(output_array = [])
+    @queue.consume_log_into(output_array)
+    output_array.should == TOO_MUCH_DATA
+  end
+
+  after do
+    FileUtils.rm_r(@tmp_path)
+  end
+end

--- a/spec/disk_backed_queue_with_persistent_queue_buffer_spec.rb
+++ b/spec/disk_backed_queue_with_persistent_queue_buffer_spec.rb
@@ -1,0 +1,67 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+class FakeBackingQueue < Array
+  def consume_log_into(other)
+    MAX_PRIMARY_SIZE.times do
+      if v = shift
+        other.push v
+      end
+    end
+  end
+end
+
+describe "StarlingServer::DiskBackedQueueWithPersistentQueueBuffer" do
+  before do
+    @primary_queue = []
+    @backing_queue = FakeBackingQueue.new
+    @queue = StarlingServer::DiskBackedQueueWithPersistentQueueBuffer.new(@primary_queue, @backing_queue)
+  end
+
+  it "should refer the first #{MAX_PRIMARY_SIZE} to the primary queue" do
+    MAX_PRIMARY_SIZE.times do
+      @queue.push "hello"
+    end
+    @primary_queue.length.should == MAX_PRIMARY_SIZE
+    @backing_queue.should be_empty
+  end
+
+  it "should refer the #{MAX_PRIMARY_SIZE+1}th message to the backing queue" do
+    (MAX_PRIMARY_SIZE+1).times do
+      @queue.push "hello"
+    end
+    @primary_queue.length.should == MAX_PRIMARY_SIZE
+    @backing_queue.length.should == 1
+  end
+
+  it "should pop messages off the primary first" do
+    (MAX_PRIMARY_SIZE+1).times do
+      @queue.push "hello"
+    end
+
+    @queue.pop
+
+    @primary_queue.length.should == MAX_PRIMARY_SIZE - 1
+    @backing_queue.length.should == 1
+  end
+
+  it "should pop messages off the backing queue once the primary is empty" do
+    (MAX_PRIMARY_SIZE+1).times do
+      @queue.push "hello"
+    end
+
+    MAX_PRIMARY_SIZE.times{ @queue.pop }
+
+    @primary_queue.should be_empty
+    @backing_queue.should_not be_empty
+
+    @queue.pop.should == "hello"
+    @queue.empty?
+  end
+
+  it "should total both the lengths" do
+    (MAX_PRIMARY_SIZE+1).times do
+      @queue.push "hello"
+    end
+    @queue.length.should == MAX_PRIMARY_SIZE+1
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,41 @@
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+
+require 'rubygems'
+require 'fileutils'
+require 'memcache'
+require 'digest/md5'
+require 'starling'
+
+require 'starling/server'
+
+class StarlingServer::PersistentQueue
+  remove_const :SOFT_LOG_MAX_SIZE
+  SOFT_LOG_MAX_SIZE = 16 * 1024 # 16 KB
+end
+
+class StarlingServer::DiskBackedQueueWithPersistentQueueBuffer
+  remove_const :MAX_PRIMARY_SIZE
+  MAX_PRIMARY_SIZE = 10
+end
+
+class StarlingServer::DiskBackedQueue
+  remove_const :MAX_LOGFILE_SIZE
+  MAX_LOGFILE_SIZE = 10
+end
+
+MAX_PRIMARY_SIZE = StarlingServer::DiskBackedQueueWithPersistentQueueBuffer::MAX_PRIMARY_SIZE
+MAX_LOGFILE_SIZE = StarlingServer::DiskBackedQueue::MAX_LOGFILE_SIZE
+
+def safely_fork(&block)
+  # anti-race juice:
+  blocking = true
+  Signal.trap("USR1") { blocking = false }
+
+  pid = Process.fork(&block)
+
+  while blocking
+    sleep 0.1
+  end
+
+  pid
+end

--- a/spec/starling_server_spec.rb
+++ b/spec/starling_server_spec.rb
@@ -17,9 +17,9 @@ def safely_fork(&block)
   # anti-race juice:
   blocking = true
   Signal.trap("USR1") { blocking = false }
-  
+
   pid = Process.fork(&block)
-  
+
   while blocking
     sleep 0.1
   end
@@ -27,34 +27,44 @@ def safely_fork(&block)
   pid
 end
 
+def start_server
+  @server_pid = safely_fork do
+    server = StarlingServer::Base.new(:host => '127.0.0.1',
+                                      :port => 22133,
+                                      :path => @tmp_path,
+                                      :logger => Logger.new(STDERR),
+                                      :log_level => Logger::FATAL)
+    Signal.trap("INT") {
+      server.stop
+      exit
+    }
+
+    Process.kill("USR1", Process.ppid)
+    server.run
+  end
+end
+
+def stop_server
+  Process.kill("INT", @server_pid)
+  Process.wait(@server_pid)
+  @client.reset
+end
+
 describe "StarlingServer" do
   before do
     @tmp_path = File.join(File.dirname(__FILE__), "tmp")
-    
+
     begin
       Dir::mkdir(@tmp_path)
     rescue Errno::EEXIST
     end
 
-    @server_pid = safely_fork do
-      server = StarlingServer::Base.new(:host => '127.0.0.1',
-                                        :port => 22133,
-                                        :path => @tmp_path,
-                                        :logger => Logger.new(STDERR),
-                                        :log_level => Logger::FATAL)
-      Signal.trap("INT") {
-        server.stop
-        exit
-      }
-
-      Process.kill("USR1", Process.ppid)
-      server.run
-    end
+    start_server
 
     @client = MemCache.new('127.0.0.1:22133')
 
   end
-  
+
   it "should test if temp_path exists and is writeable" do
     File.exist?(@tmp_path).should be_true
     File.directory?(@tmp_path).should be_true
@@ -67,16 +77,29 @@ describe "StarlingServer" do
     @client.set('test_set_and_get_one_entry', v)
     @client.get('test_set_and_get_one_entry').should eql(v)
   end
-  
+
+  it "should list queues at startup" do
+    @client.set("example_queue", "hello")
+    stop_server
+    start_server
+
+    stats = @client.stats
+    stats.has_key?('127.0.0.1:22133').should be_true
+    server_stats = stats['127.0.0.1:22133']
+
+    server_stats.keys.grep( /queue_.*_total_items/ ).size.should eql(1)
+    server_stats["queue_example_queue_total_items"].should eql(1)
+  end
+
   it "should respond to delete" do
-    @client.delete("my_queue").should eql("END\r\n")   
+    @client.delete("my_queue").should eql("END\r\n")
     starling_client = Starling.new('127.0.0.1:22133')
     starling_client.set('my_queue', 50)
     starling_client.available_queues.size.should eql(1)
     starling_client.delete("my_queue")
     starling_client.available_queues.size.should eql(0)
   end
-  
+
   it "should expire entries" do
     v = rand((2**32)-1)
     @client.get('test_set_with_expiry').should be_nil
@@ -97,7 +120,7 @@ describe "StarlingServer" do
     stats.has_key?('queue_test_age_age').should be_true
     (stats['queue_test_age_age'] >= 1000).should be_true
   end
-  
+
   it "should rotate log" do
     log_rotation_path = File.join(@tmp_path, 'test_log_rotation')
 
@@ -126,9 +149,9 @@ describe "StarlingServer" do
     stats = @client.stats
     stats.kind_of? Hash
     stats.has_key?('127.0.0.1:22133').should be_true
-    
+
     server_stats = stats['127.0.0.1:22133']
-    
+
     basic_stats = %w( bytes pid time limit_maxbytes cmd_get version
                       bytes_written cmd_set get_misses total_connections
                       curr_connections curr_items uptime get_hits total_items
@@ -152,12 +175,12 @@ describe "StarlingServer" do
     @client.reset
     @client.get('test_that_disconnecting_and_reconnecting_works').should eql(v)
   end
-  
+
   it "should use epoll on linux" do
     # this may take a few seconds.
     # the point is to make sure that we're using epoll on Linux, so we can
     # handle more than 1024 connections.
-    
+
     unless IO::popen("uname").read.chomp == "Linux"
       pending "skipping epoll test: not on Linux"
     end
@@ -166,7 +189,7 @@ describe "StarlingServer" do
     unless fd_limit > 1024
       pending "skipping epoll test: 'ulimit -n' = #{fd_limit}, need > 1024"
     end
-    
+
     v = rand(2**32 - 1)
     @client.set('test_epoll', v)
 
@@ -197,7 +220,7 @@ describe "StarlingServer" do
       Process.kill("TERM", pid2)
     end
   end
-  
+
   it "should raise error if queue collection is an invalid path" do
     invalid_path = nil
     while invalid_path.nil? || File.exist?(invalid_path)
@@ -208,11 +231,9 @@ describe "StarlingServer" do
       StarlingServer::QueueCollection.new(invalid_path)
     }.should raise_error(StarlingServer::InaccessibleQueuePath)
   end
-  
+
   after do
-    Process.kill("INT", @server_pid)
-    Process.wait(@server_pid)
-    @client.reset
+    stop_server
     FileUtils.rm(Dir.glob(File.join(@tmp_path, '*')))
   end
 end


### PR DESCRIPTION
We've been using starling very heavily here at Reevoo, and have made some substantial changes to it.

In this pull request we have:
- Fixed the delete command (the 2nd option is optional according to the memcache spec)
- Added a disk backed queue for when the in memory queue size gets above 10,000 messages.

This prevents memory consumption bringing the box to it's knees when a poller outage causes millions of messages to queue up.

Our experimentation showed that a starling queue with more than 100k messages in a single queue would grind to a halt.

Adding the disk backed queues for everything after the first 10k, then loading the disk backed store back in again 10k at a time kept the queue responsive at all times.

We've been using this in production, processing well in excess of 2million messages a day since mid September, with queues occasionally hitting the 1.5million messages mark without any slow down.

I would really like to get this into mainline at some point.

What do you guys think?
