### PR TITLE
Fix delete command

### DIFF
--- a/lib/starling/handler.rb
+++ b/lib/starling/handler.rb
@@ -24,7 +24,7 @@ module StarlingServer
     SET_CLIENT_DATA_ERROR = "CLIENT_ERROR bad data chunk\r\nERROR\r\n".freeze
     
     # DELETE Responses
-    DELETE_COMMAND = /\Adelete (.{1,250}) ([0-9]+)\r\n/m
+    DELETE_COMMAND = /\Adelete (.{1,250})(?: ([0-9]+))?\r\n/m
     DELETE_RESPONSE = "END\r\n".freeze
 
     # STAT Response


### PR DESCRIPTION
This makes the existing tests pass. It was failing as it was expecting a 2nd parameter which is unused for starling and optional for memcached [1].

The test was failing with memcache-client-1.8.5, and passes with a this patch applied.

[1] http://code.sixapart.com/svn/memcached/trunk/server/doc/protocol.txt
