### PR TITLE
Load queues at startup

### DIFF
--- a/lib/starling/queue_collection.rb
+++ b/lib/starling/queue_collection.rb
@@ -27,6 +27,7 @@ module StarlingServer
       @queue_init_mutexes = {}
 
       @stats = Hash.new(0)
+      initialize_existing_queues!
     end
 
     ##
@@ -139,6 +140,13 @@ module StarlingServer
     end
 
     private
+
+    def initialize_existing_queues!
+      Dir.glob(File.join(@path, "*")).each {|file|
+        next if File.directory?( file )
+        queues(File.basename(file))
+      }
+    end
 
     def current_size #:nodoc:
       @queues.inject(0) { |m, (k,v)| m + v.length }

--- a/spec/starling_server_spec.rb
+++ b/spec/starling_server_spec.rb
@@ -17,9 +17,9 @@ def safely_fork(&block)
   # anti-race juice:
   blocking = true
   Signal.trap("USR1") { blocking = false }
-  
+
   pid = Process.fork(&block)
-  
+
   while blocking
     sleep 0.1
   end
@@ -27,34 +27,44 @@ def safely_fork(&block)
   pid
 end
 
+def start_server
+  @server_pid = safely_fork do
+    server = StarlingServer::Base.new(:host => '127.0.0.1',
+                                      :port => 22133,
+                                      :path => @tmp_path,
+                                      :logger => Logger.new(STDERR),
+                                      :log_level => Logger::FATAL)
+    Signal.trap("INT") {
+      server.stop
+      exit
+    }
+
+    Process.kill("USR1", Process.ppid)
+    server.run
+  end
+end
+
+def stop_server
+  Process.kill("INT", @server_pid)
+  Process.wait(@server_pid)
+  @client.reset
+end
+
 describe "StarlingServer" do
   before do
     @tmp_path = File.join(File.dirname(__FILE__), "tmp")
-    
+
     begin
       Dir::mkdir(@tmp_path)
     rescue Errno::EEXIST
     end
 
-    @server_pid = safely_fork do
-      server = StarlingServer::Base.new(:host => '127.0.0.1',
-                                        :port => 22133,
-                                        :path => @tmp_path,
-                                        :logger => Logger.new(STDERR),
-                                        :log_level => Logger::FATAL)
-      Signal.trap("INT") {
-        server.stop
-        exit
-      }
-
-      Process.kill("USR1", Process.ppid)
-      server.run
-    end
+    start_server
 
     @client = MemCache.new('127.0.0.1:22133')
 
   end
-  
+
   it "should test if temp_path exists and is writeable" do
     File.exist?(@tmp_path).should be_true
     File.directory?(@tmp_path).should be_true
@@ -67,16 +77,29 @@ describe "StarlingServer" do
     @client.set('test_set_and_get_one_entry', v)
     @client.get('test_set_and_get_one_entry').should eql(v)
   end
-  
+
+  it "should list queues at startup" do
+    @client.set("example_queue", "hello")
+    stop_server
+    start_server
+
+    stats = @client.stats
+    stats.has_key?('127.0.0.1:22133').should be_true
+    server_stats = stats['127.0.0.1:22133']
+
+    server_stats.keys.grep( /queue_.*_total_items/ ).size.should eql(1)
+    server_stats["queue_example_queue_total_items"].should eql(1)
+  end
+
   it "should respond to delete" do
-    @client.delete("my_queue").should eql("END\r\n")   
+    @client.delete("my_queue").should eql("END\r\n")
     starling_client = Starling.new('127.0.0.1:22133')
     starling_client.set('my_queue', 50)
     starling_client.available_queues.size.should eql(1)
     starling_client.delete("my_queue")
     starling_client.available_queues.size.should eql(0)
   end
-  
+
   it "should expire entries" do
     v = rand((2**32)-1)
     @client.get('test_set_with_expiry').should be_nil
@@ -97,7 +120,7 @@ describe "StarlingServer" do
     stats.has_key?('queue_test_age_age').should be_true
     (stats['queue_test_age_age'] >= 1000).should be_true
   end
-  
+
   it "should rotate log" do
     log_rotation_path = File.join(@tmp_path, 'test_log_rotation')
 
@@ -126,9 +149,9 @@ describe "StarlingServer" do
     stats = @client.stats
     stats.kind_of? Hash
     stats.has_key?('127.0.0.1:22133').should be_true
-    
+
     server_stats = stats['127.0.0.1:22133']
-    
+
     basic_stats = %w( bytes pid time limit_maxbytes cmd_get version
                       bytes_written cmd_set get_misses total_connections
                       curr_connections curr_items uptime get_hits total_items
@@ -152,12 +175,12 @@ describe "StarlingServer" do
     @client.reset
     @client.get('test_that_disconnecting_and_reconnecting_works').should eql(v)
   end
-  
+
   it "should use epoll on linux" do
     # this may take a few seconds.
     # the point is to make sure that we're using epoll on Linux, so we can
     # handle more than 1024 connections.
-    
+
     unless IO::popen("uname").read.chomp == "Linux"
       pending "skipping epoll test: not on Linux"
     end
@@ -166,7 +189,7 @@ describe "StarlingServer" do
     unless fd_limit > 1024
       pending "skipping epoll test: 'ulimit -n' = #{fd_limit}, need > 1024"
     end
-    
+
     v = rand(2**32 - 1)
     @client.set('test_epoll', v)
 
@@ -197,7 +220,7 @@ describe "StarlingServer" do
       Process.kill("TERM", pid2)
     end
   end
-  
+
   it "should raise error if queue collection is an invalid path" do
     invalid_path = nil
     while invalid_path.nil? || File.exist?(invalid_path)
@@ -208,11 +231,9 @@ describe "StarlingServer" do
       StarlingServer::QueueCollection.new(invalid_path)
     }.should raise_error(StarlingServer::InaccessibleQueuePath)
   end
-  
+
   after do
-    Process.kill("INT", @server_pid)
-    Process.wait(@server_pid)
-    @client.reset
+    stop_server
     FileUtils.rm(Dir.glob(File.join(@tmp_path, '*')))
   end
 end


### PR DESCRIPTION
This patch should fix issue #4.

Loading large transaction logs at load would routinely timeout but still pop/push the first message, this was bad.

Also queues could not be seen until first access after reboot.
